### PR TITLE
Fix sample URL

### DIFF
--- a/plugin-name/plugin-name.php
+++ b/plugin-name/plugin-name.php
@@ -125,7 +125,7 @@ function pn_fs() {
 			$pn_fs->add_filter(
 				'support_forum_url',
 				static function ( $wp_org_support_forum_url ) {
-					return 'http://your url';
+					return 'https://your-url.test';
 				}
 			);
 		}


### PR DESCRIPTION
- `.test` TLD for testing
- [HTTPS is everywhere](https://www.eff.org/https-everywhere), even in development