### PR TITLE
Fix #189: Add Tagged

### DIFF
--- a/plugin-name/composer.json
+++ b/plugin-name/composer.json
@@ -16,6 +16,7 @@
         "ayecode/wp-super-duper": "^1.0",
         "cmb2/cmb2": "2.9.*",
         "composer/installers": "1.x",
+        "decodelabs/tagged": "^0.11.9",
         "freemius/wordpress-sdk": "2.4.*",
         "johnbillion/extended-cpts": "4.5.*",
         "julien731/wp-review-me": "dev-develop",

--- a/plugin-name/internals/Shortcode.php
+++ b/plugin-name/internals/Shortcode.php
@@ -12,6 +12,7 @@
 
 namespace Plugin_Name\Internals;
 
+use DecodeLabs\Tagged as Html;
 use Plugin_Name\Engine\Base;
 
 /**
@@ -40,8 +41,7 @@ class Shortcode extends Base {
 	public static function foobar_func( array $atts ) {
 		\shortcode_atts( array( 'foo' => 'something', 'bar' => 'something else' ), $atts );
 
-		return '<span class="foo">foo = ' . $atts[ 'foo' ] . '</span>' .
-			'<span class="bar">foo = ' . $atts[ 'bar' ] . '</span>';
+		return Html::{'span.foo'}( 'foo = ' . $atts['foo'] ) . Html::{'span.bar'}( 'foo = ' . $atts['bar'] );
 	}
 
 }

--- a/plugin-name/internals/Shortcode.php
+++ b/plugin-name/internals/Shortcode.php
@@ -41,7 +41,7 @@ class Shortcode extends Base {
 	public static function foobar_func( array $atts ) {
 		\shortcode_atts( array( 'foo' => 'something', 'bar' => 'something else' ), $atts );
 
-		return Html::{'span.foo'}( 'foo = ' . $atts['foo'] ) . Html::{'span.bar'}( 'foo = ' . $atts['bar'] );
+		return Html::{'span.foo'}( 'foo = ' . $atts['foo'] ) . Html::{'span.bar'}( 'bar = ' . $atts['bar'] );
 	}
 
 }

--- a/plugin-name/wp-config-test.php
+++ b/plugin-name/wp-config-test.php
@@ -5,10 +5,10 @@
 define('DB_NAME', 'wordpress_unit_tests');
 
 /** MySQL database username */
-define('DB_USER', 'root');
+define('DB_USER', 'wpbp');
 
 /** MySQL database password */
-define('DB_PASSWORD', 'test');
+define('DB_PASSWORD', 'my-strong-pass');
 
 /** MySQL hostname */
 define('DB_HOST', 'localhost');


### PR DESCRIPTION
This PR fixes #189 

Requires [decodelabs/tagged](https://github.com/decodelabs/tagged) and uses it instead of hardcoded HTML.

Last commit in this PR fixes what I assume is a small issue with the output. Old output was:

```html
 <span class="foo">foo = test</span><span class="bar">foo = lol</span>
```

New output is:

```html
 <span class="foo">foo = test</span><span class="bar">bar = lol</span>
```

Didn't feel like this needed a separate PR, but happy to drop the commit or split it.