### PR TITLE
Fix "Plugin Name" displaying instead of plugin name

### DIFF
--- a/plugin-name/engine/Initialize.php
+++ b/plugin-name/engine/Initialize.php
@@ -15,7 +15,7 @@ namespace Plugin_Name\Engine;
 use Plugin_Name\Engine;
 
 /**
- * Plugin Name Initializer
+ * Plugin_Name Initializer
  */
 class Initialize {
 


### PR DESCRIPTION
When I ran the generator I noticed this in my `Initialize.php`. I assume this should be the actual name of the plugin.