### PR TITLE
Do not initialize abstract classes

### DIFF
--- a/plugin-name/engine/Initialize.php
+++ b/plugin-name/engine/Initialize.php
@@ -95,10 +95,13 @@ class Initialize {
 
 		foreach ( $this->classes as $class ) {
 			try {
-				$temp = new $class;
+				$reflection = new \ReflectionClass( $class );
+				if ( ! $reflection->isAbstract() ) {
+					$temp = new $class();
 
-				if ( \method_exists( $temp, 'initialize' ) ) {
-					$temp->initialize();
+					if ( \method_exists( $temp, 'initialize' ) ) {
+						$temp->initialize();
+					}
 				}
 			} catch ( \Throwable $err ) {
 				\do_action( 'plugin_name_initialize_failed', $err );


### PR DESCRIPTION
I found myself in a situation where I needed to declare an abstract class, and it was automatically picked and initialized by Engine\Initialize, resulting in an error.
We can fix this by first checking if the class we are going to initialize isn't an abstract one.